### PR TITLE
Remove All, error message upon invalid JSON, avoid rewriting several times

### DIFF
--- a/data/prefs.css
+++ b/data/prefs.css
@@ -37,13 +37,13 @@ td, th {
   table, thead, tbody, th, td, tr {
     display: block;
   }
-  #pref_table, .button_group, .info_message {
+  #pref_table, .button_group, .info_message, #error_message {
     margin-left: 0;
   }
   #pref_table {
     width: auto;
   }
-  .button_group, .info_message, #saved_text {
+  .button_group, .info_message, #error_message, #saved_text {
     font-size: 2em;
   }
   .button_group > button {
@@ -91,4 +91,8 @@ td, th {
 .experimental_group {
   font-style: italic;
   font-size: larger;
+}
+
+.hidden {
+  display: none;
 }

--- a/data/prefs.html
+++ b/data/prefs.html
@@ -18,7 +18,7 @@
         <th>Phrase
         <th>Rewrite to
         <th>Ignore case
-        <th>Match word (Latin letter only)
+        <th>Match word (For Latin letters only)
         <th>Smart case
       </tr>
     </table>

--- a/data/prefs.html
+++ b/data/prefs.html
@@ -32,6 +32,9 @@
     <div class="info_message">
       <span style="font-variant:small-caps;font-weight:bold;">Note: </span>
       Empty rows are not saved.</div>
+    <div id="error_message" class="hidden">
+      <span style="font-variant:small-caps;font-weight:bold;">Error: </span>
+      Cannot import - invalid JSON.</div>
     <textarea id="scratchpad"></textarea>
     <script src="prefs.js"></script>
   </body>

--- a/data/prefs.html
+++ b/data/prefs.html
@@ -18,7 +18,7 @@
         <th>Phrase
         <th>Rewrite to
         <th>Ignore case
-        <th>Match word
+        <th>Match word (Latin letter only)
         <th>Smart case
       </tr>
     </table>

--- a/data/prefs.html
+++ b/data/prefs.html
@@ -26,6 +26,7 @@
       <button id="add_button" type="button">Add Rule</button>
       <button id="save_button" type="button">Save</button>
       <button id="import_button" type="button">Import</button>
+      <button id="purge_button" type="button">Remove All</button>
       <div id="saved_text" style="display:none;">Saved</div>
     </div>
     <div class="info_message">

--- a/data/prefs.js
+++ b/data/prefs.js
@@ -136,7 +136,7 @@ document.addEventListener('DOMContentLoaded', function () {
     import_btn.addEventListener('click', function () {
         try {
             initFromData(JSON.parse(scratchpad.value));
-			save_btn.click();
+            save_btn.click();
         } catch (e) {
             error_message.classList.remove('hidden');
             setTimeout(clearErrorMessages, 2000);

--- a/data/prefs.js
+++ b/data/prefs.js
@@ -5,6 +5,7 @@ const storage = api.storage.local;
 const table = document.getElementById("pref_table"),
     save_btn = document.getElementById("save_button"),
     import_btn = document.getElementById("import_button"),
+    purge_btn = document.getElementById("purge_button"),
     add_btn = document.getElementById("add_button"),
     scratchpad = document.getElementById("scratchpad"),
     default_replacements = [{
@@ -129,6 +130,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
     import_btn.addEventListener('click', function () {
         initFromData(JSON.parse(scratchpad.value));
+        save_btn.click();
+    });
+
+    purge_btn.addEventListener('click', function () {
+        const rows = table.children;
+        for (let i = rows.length - 1; i >= 1; i--) {
+            table.removeChild(rows[i]);
+        }
+
         save_btn.click();
     });
 

--- a/data/prefs.js
+++ b/data/prefs.js
@@ -15,7 +15,8 @@ const table = document.getElementById("pref_table"),
         "mw": false,
         "sc": false,
     }],
-    use_dynamic_cb = document.getElementById("use_dynamic_checkbox");
+    use_dynamic_cb = document.getElementById("use_dynamic_checkbox"),
+    error_message = document.getElementById("error_message");
 
 // Make a span element with the given text and class.
 function makeSpan(cl, text) {
@@ -88,6 +89,10 @@ function initFromData(replacements) {
     }
 }
 
+function clearErrorMessages () {
+    error_message.classList.add('hidden');
+}
+
 let saveTimeout;
 // When document ready, add current preferences and attach buttons.
 document.addEventListener('DOMContentLoaded', function () {
@@ -129,8 +134,13 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     import_btn.addEventListener('click', function () {
-        initFromData(JSON.parse(scratchpad.value));
-        save_btn.click();
+        try {
+            initFromData(JSON.parse(scratchpad.value));
+			save_btn.click();
+        } catch (e) {
+            error_message.classList.remove('hidden');
+            setTimeout(clearErrorMessages, 2000);
+        }
     });
 
     purge_btn.addEventListener('click', function () {

--- a/data/text-rewriter.js
+++ b/data/text-rewriter.js
@@ -121,14 +121,14 @@ function treeReplace(target, replacements, visitSet) {
 
             // Ignore elements whose content was already changed, to avoid rewriting several times.
             if (!cur.textRewriterModified) {
-				const {text, count} = performReplacements(cur.nodeValue, replacements);
-				cur.nodeValue = text;
-				if (count) {
-					cur.textRewriterModified = true;
-				}
-				totalCount += count;
-				visited++;
-			}
+                const {text, count} = performReplacements(cur.nodeValue, replacements);
+                cur.nodeValue = text;
+                if (count) {
+                    cur.textRewriterModified = true;
+                }
+                totalCount += count;
+                visited++;
+            }
         }
     }
     return {totalCount, visited};

--- a/data/text-rewriter.js
+++ b/data/text-rewriter.js
@@ -118,10 +118,17 @@ function treeReplace(target, replacements, visitSet) {
                     continue;
                 }
             }
-            const {text, count} = performReplacements(cur.nodeValue, replacements);
-            cur.nodeValue = text;
-            totalCount += count;
-            visited++;
+
+            // Ignore elements whose content was already changed, to avoid rewriting several times.
+            if (!cur.textRewriterModified) {
+				const {text, count} = performReplacements(cur.nodeValue, replacements);
+				cur.nodeValue = text;
+				if (count) {
+					cur.textRewriterModified = true;
+				}
+				totalCount += count;
+				visited++;
+			}
         }
     }
     return {totalCount, visited};


### PR DESCRIPTION
- Ignore elements whose content was already changed, to avoid rewriting several times
  E.g. replacement "Janis => Janis (author)" could produce "Janis (author) (author) (author) ..."
- Add "Remove All" command
- Display error message upon import failure 